### PR TITLE
Adding generative effect type

### DIFF
--- a/Pokora.xcodeproj/project.pbxproj
+++ b/Pokora.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0A7FBC5D2A034664008DFFAC /* VideoStore+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7FBC5C2A034664008DFFAC /* VideoStore+Export.swift */; };
 		0A8014522A01ECA3001BEB1B /* NewEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8014512A01ECA3001BEB1B /* NewEffectView.swift */; };
 		0A8933362A169AE800E94476 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8933352A169AE800E94476 /* SettingsView.swift */; };
+		0A8933382A16C46A00E94476 /* VideoStore+Effects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8933372A16C46A00E94476 /* VideoStore+Effects.swift */; };
 		0AAC1D6629CCBD53009C1402 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = 0AAC1D6529CCBD53009C1402 /* StableDiffusion */; };
 		0AB1859829A6873200BCC57C /* PokoraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB1859729A6873200BCC57C /* PokoraApp.swift */; };
 		0AB1859C29A6873300BCC57C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AB1859B29A6873300BCC57C /* Assets.xcassets */; };
@@ -54,6 +55,7 @@
 		0A7FBC5C2A034664008DFFAC /* VideoStore+Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoStore+Export.swift"; sourceTree = "<group>"; };
 		0A8014512A01ECA3001BEB1B /* NewEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEffectView.swift; sourceTree = "<group>"; };
 		0A8933352A169AE800E94476 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		0A8933372A16C46A00E94476 /* VideoStore+Effects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoStore+Effects.swift"; sourceTree = "<group>"; };
 		0AACA29B2A0BF851006DB3BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0AB1859429A6873200BCC57C /* Pokora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pokora.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AB1859729A6873200BCC57C /* PokoraApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokoraApp.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				0A191D3E29FF2B230011A439 /* VideoStore+Player.swift */,
 				0A3B463E2A00914C0066F462 /* VideoStore+TimeObserver.swift */,
 				0A7FBC542A031F80008DFFAC /* VideoStore+Video.swift */,
+				0A8933372A16C46A00E94476 /* VideoStore+Effects.swift */,
 				0A7FBC5A2A0325E2008DFFAC /* VideoStore+StableDiffusion.swift */,
 				0A7FBC5C2A034664008DFFAC /* VideoStore+Export.swift */,
 				0AE8DC552A0E9B520097F169 /* VideoStore+Uprez.swift */,
@@ -258,6 +261,7 @@
 				0A3B463F2A00914C0066F462 /* VideoStore+TimeObserver.swift in Sources */,
 				0A7FBC592A0321A3008DFFAC /* ProcessingView.swift in Sources */,
 				0A191D3329FEFCB50011A439 /* VideoPlayerView.swift in Sources */,
+				0A8933382A16C46A00E94476 /* VideoStore+Effects.swift in Sources */,
 				0A7FBC572A03201F008DFFAC /* Frame.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pokora.xcodeproj/project.pbxproj
+++ b/Pokora.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0A8014522A01ECA3001BEB1B /* NewEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8014512A01ECA3001BEB1B /* NewEffectView.swift */; };
 		0A8933362A169AE800E94476 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8933352A169AE800E94476 /* SettingsView.swift */; };
 		0A8933382A16C46A00E94476 /* VideoStore+Effects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8933372A16C46A00E94476 /* VideoStore+Effects.swift */; };
+		0A89333A2A16DA1D00E94476 /* VideoStore+Transformations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8933392A16DA1D00E94476 /* VideoStore+Transformations.swift */; };
 		0AAC1D6629CCBD53009C1402 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = 0AAC1D6529CCBD53009C1402 /* StableDiffusion */; };
 		0AB1859829A6873200BCC57C /* PokoraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB1859729A6873200BCC57C /* PokoraApp.swift */; };
 		0AB1859C29A6873300BCC57C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AB1859B29A6873300BCC57C /* Assets.xcassets */; };
@@ -56,6 +57,7 @@
 		0A8014512A01ECA3001BEB1B /* NewEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEffectView.swift; sourceTree = "<group>"; };
 		0A8933352A169AE800E94476 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0A8933372A16C46A00E94476 /* VideoStore+Effects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoStore+Effects.swift"; sourceTree = "<group>"; };
+		0A8933392A16DA1D00E94476 /* VideoStore+Transformations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoStore+Transformations.swift"; sourceTree = "<group>"; };
 		0AACA29B2A0BF851006DB3BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0AB1859429A6873200BCC57C /* Pokora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pokora.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AB1859729A6873200BCC57C /* PokoraApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokoraApp.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				0A7FBC5A2A0325E2008DFFAC /* VideoStore+StableDiffusion.swift */,
 				0A7FBC5C2A034664008DFFAC /* VideoStore+Export.swift */,
 				0AE8DC552A0E9B520097F169 /* VideoStore+Uprez.swift */,
+				0A8933392A16DA1D00E94476 /* VideoStore+Transformations.swift */,
 				0A42206C2A0BFA9900274EF0 /* PokoraProject.swift */,
 				0A42206E2A0C035D00274EF0 /* PokoraProject+Effects.swift */,
 			);
@@ -245,6 +248,7 @@
 				0A191D3929FF08750011A439 /* VideoStore.swift in Sources */,
 				0A191D3D29FF25B50011A439 /* Effect.swift in Sources */,
 				0AE8DC5E2A1537830097F169 /* ThumbnailScrollView.swift in Sources */,
+				0A89333A2A16DA1D00E94476 /* VideoStore+Transformations.swift in Sources */,
 				0A42206D2A0BFA9900274EF0 /* PokoraProject.swift in Sources */,
 				0A7FBC5D2A034664008DFFAC /* VideoStore+Export.swift in Sources */,
 				0A8014522A01ECA3001BEB1B /* NewEffectView.swift in Sources */,

--- a/Pokora/Model/Effect.swift
+++ b/Pokora/Model/Effect.swift
@@ -18,6 +18,9 @@ struct Effect: Identifiable, Codable {
     var endStrength: Float = 0.2
     var seed: UInt32 = globalSeed
     var prompt: String = "a cyberpunk cityscape"
+    var numberFramesToProcess: Int {
+        (endFrame - startFrame) + 1
+    }
     
     func strength(forFrameIndex index: Int) -> Float {
         if startStrength == endStrength {

--- a/Pokora/Model/Effect.swift
+++ b/Pokora/Model/Effect.swift
@@ -27,6 +27,7 @@ struct Effect: Identifiable, Codable {
     var startStrength: Float = 0.2
     var endStrength: Float = 0.2
     var seed: UInt32 = globalSeed
+    var stepCount: Int? = 30
     var prompt: String = "a cyberpunk cityscape"
     var effectType: EffectType? = .direct
     
@@ -56,7 +57,7 @@ struct Effect: Identifiable, Codable {
         self.endFrame = endFrame
     }
     
-    init(effectType: Effect.EffectType, startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, prompt: String, rotateDirection: RotateDirection? = nil, rotateAngle: Float? = nil, zoomScale: Float? = nil) {
+    init(effectType: Effect.EffectType, startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, stepCount: Int, prompt: String, rotateDirection: RotateDirection? = nil, rotateAngle: Float? = nil, zoomScale: Float? = nil) {
         self.id = UUID()
         self.effectType = effectType
         self.startFrame = startFrame
@@ -64,6 +65,7 @@ struct Effect: Identifiable, Codable {
         self.startStrength = startStrength
         self.endStrength = endStrength
         self.seed = seed
+        self.stepCount = stepCount
         self.prompt = prompt
         self.rotateAngle = rotateAngle
         self.rotateDirection = rotateDirection
@@ -79,6 +81,7 @@ struct Effect: Identifiable, Codable {
         self.startStrength = existingEffect.startStrength
         self.endStrength = existingEffect.endStrength
         self.seed = existingEffect.seed
+        self.stepCount = existingEffect.stepCount
         self.prompt = existingEffect.prompt
         self.rotateAngle = existingEffect.rotateAngle
         self.rotateDirection = existingEffect.rotateDirection

--- a/Pokora/Model/Effect.swift
+++ b/Pokora/Model/Effect.swift
@@ -10,6 +10,11 @@ import Foundation
 let globalSeed = UInt32.random(in: 0...UInt32.max)
 
 struct Effect: Identifiable, Codable {
+    enum EffectType: String, Codable, CaseIterable {
+        case direct
+        case generative
+    }
+
     var id = UUID()
     var startFrame: Int
     var endFrame: Int
@@ -18,6 +23,8 @@ struct Effect: Identifiable, Codable {
     var endStrength: Float = 0.2
     var seed: UInt32 = globalSeed
     var prompt: String = "a cyberpunk cityscape"
+    var effectType: EffectType? = .direct
+    
     var numberFramesToProcess: Int {
         (endFrame - startFrame) + 1
     }
@@ -40,8 +47,9 @@ struct Effect: Identifiable, Codable {
         self.endFrame = endFrame
     }
     
-    init(startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, prompt: String) {
+    init(effectType: Effect.EffectType, startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, prompt: String) {
         self.id = UUID()
+        self.effectType = effectType
         self.startFrame = startFrame
         self.endFrame = endFrame
         self.startStrength = startStrength
@@ -53,6 +61,7 @@ struct Effect: Identifiable, Codable {
     // Ease of use for copying
     init(from existingEffect: Effect) {
         self.id = existingEffect.id
+        self.effectType = existingEffect.effectType
         self.startFrame = existingEffect.startFrame
         self.endFrame = existingEffect.endFrame
         self.startStrength = existingEffect.startStrength

--- a/Pokora/Model/Effect.swift
+++ b/Pokora/Model/Effect.swift
@@ -14,6 +14,11 @@ struct Effect: Identifiable, Codable {
         case direct
         case generative
     }
+    
+    enum RotateDirection: Float, Codable {
+        case clockwise = 1.0
+        case counterclockwise = -1.0
+    }
 
     var id = UUID()
     var startFrame: Int
@@ -24,6 +29,10 @@ struct Effect: Identifiable, Codable {
     var seed: UInt32 = globalSeed
     var prompt: String = "a cyberpunk cityscape"
     var effectType: EffectType? = .direct
+    
+    var rotateDirection: RotateDirection? = nil
+    var rotateAngle: Float? = nil
+    var zoomScale: Float? = nil
     
     var numberFramesToProcess: Int {
         (endFrame - startFrame) + 1
@@ -47,7 +56,7 @@ struct Effect: Identifiable, Codable {
         self.endFrame = endFrame
     }
     
-    init(effectType: Effect.EffectType, startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, prompt: String) {
+    init(effectType: Effect.EffectType, startFrame: Int, endFrame: Int, startStrength: Float, endStrength: Float, seed: UInt32, prompt: String, rotateDirection: RotateDirection? = nil, rotateAngle: Float? = nil, zoomScale: Float? = nil) {
         self.id = UUID()
         self.effectType = effectType
         self.startFrame = startFrame
@@ -56,6 +65,9 @@ struct Effect: Identifiable, Codable {
         self.endStrength = endStrength
         self.seed = seed
         self.prompt = prompt
+        self.rotateAngle = rotateAngle
+        self.rotateDirection = rotateDirection
+        self.zoomScale = zoomScale
     }
     
     // Ease of use for copying
@@ -68,5 +80,8 @@ struct Effect: Identifiable, Codable {
         self.endStrength = existingEffect.endStrength
         self.seed = existingEffect.seed
         self.prompt = existingEffect.prompt
+        self.rotateAngle = existingEffect.rotateAngle
+        self.rotateDirection = existingEffect.rotateDirection
+        self.zoomScale = existingEffect.zoomScale
     }
 }

--- a/Pokora/Model/PokoraProject+Effects.swift
+++ b/Pokora/Model/PokoraProject+Effects.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 extension PokoraProject {
-    @MainActor mutating func addEffect(effectType: Effect.EffectType, startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32) {
+    @MainActor mutating func addEffect(effectType: Effect.EffectType, startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?) {
         let currentFrame = startFrame
         let lastFrame = video.lastFrameIndex ?? currentFrame
-        let newEffect = Effect(effectType: effectType, startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, prompt: prompt)
+        let newEffect = Effect(effectType: effectType, startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, prompt: prompt, rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale)
 
         // Find the index of the next effect in the array
         if let nextEffectIndex = effects.firstIndex(where: { $0.startFrame > newEffect.startFrame }) {

--- a/Pokora/Model/PokoraProject+Effects.swift
+++ b/Pokora/Model/PokoraProject+Effects.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 extension PokoraProject {
-    @MainActor mutating func addEffect(effectType: Effect.EffectType, startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?) {
+    @MainActor mutating func addEffect(effectType: Effect.EffectType, startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32, stepCount: Int, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?) {
         let currentFrame = startFrame
         let lastFrame = video.lastFrameIndex ?? currentFrame
-        let newEffect = Effect(effectType: effectType, startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, prompt: prompt, rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale)
+        let newEffect = Effect(effectType: effectType, startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, stepCount: stepCount, prompt: prompt, rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale)
 
         // Find the index of the next effect in the array
         if let nextEffectIndex = effects.firstIndex(where: { $0.startFrame > newEffect.startFrame }) {

--- a/Pokora/Model/PokoraProject+Effects.swift
+++ b/Pokora/Model/PokoraProject+Effects.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 extension PokoraProject {
-    @MainActor mutating func addEffect(startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32) {
+    @MainActor mutating func addEffect(effectType: Effect.EffectType, startFrame: Int, prompt: String, startStrength: Float, endStrength: Float, seed: UInt32) {
         let currentFrame = startFrame
         let lastFrame = video.lastFrameIndex ?? currentFrame
-        let newEffect = Effect(startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, prompt: prompt)
+        let newEffect = Effect(effectType: effectType, startFrame: currentFrame, endFrame: lastFrame, startStrength: startStrength, endStrength: endStrength, seed: seed, prompt: prompt)
 
         // Find the index of the next effect in the array
         if let nextEffectIndex = effects.firstIndex(where: { $0.startFrame > newEffect.startFrame }) {

--- a/Pokora/Model/PokoraProject+Effects.swift
+++ b/Pokora/Model/PokoraProject+Effects.swift
@@ -45,6 +45,22 @@ extension PokoraProject {
         return false
     }
     
+    mutating func clearProcessedFrames(withEffect effect: Effect) {
+        for index in 0...(video.lastFrameIndex ?? 0) {
+            if (index >= effect.startFrame) && (index <= effect.endFrame) {
+                let fileManager = FileManager.default
+                if let url = video.frames?[index].processedUrl {
+                    do {
+                        try fileManager.removeItem(atPath: url.path)
+                    } catch let error {
+                        print("ERROR: \(error.localizedDescription)")
+                    }
+                }
+                video.frames?[index].processedUrl = nil
+            }
+        }
+    }
+    
     func getUrls(from effect: Effect) -> [URL] {
         guard let frames = video.frames else {
             return []

--- a/Pokora/Model/Video.swift
+++ b/Pokora/Model/Video.swift
@@ -18,7 +18,8 @@ struct Video: Identifiable, Codable {
         guard let frameRate = framerate, let duration = duration else {
             return nil
         }
-        return Int(round(duration * Double(frameRate)))
+        // I think this was the source of an off by one error
+        return Int(round(duration * Double(frameRate))) - 1
     }
 }
 

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -58,7 +58,7 @@ extension VideoStore {
                 let name = (url.lastPathComponent.components(separatedBy: ".").first ?? "").appending("_processed.png")
                 let fileURL = url.deletingLastPathComponent().appending(path:name)
                 if !FileManager().fileExists(atPath: fileURL.path) {
-                    let processedUrl = try process(imageUrl: url,
+                    let processedUrl = try processImageToImage(withImageUrl: url,
                                                      prompt: effect.prompt,
                                                    strength: effect.strength(forFrameIndex: frameIndex),
                                                        seed: effect.seed,

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -81,6 +81,7 @@ extension VideoStore {
                                                      prompt: effect.prompt,
                                                    strength: effect.strength(forFrameIndex: frameIndex),
                                                                seed: effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
+                                                               stepCount: effect.stepCount ?? 30,
                                                                rotateDirection: effect.rotateDirection,
                                                                rotateAngle: effect.rotateAngle,
                                                                zoomScale: effect.zoomScale,

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -78,7 +78,8 @@ extension VideoStore {
                                                    strength: effect.strength(forFrameIndex: frameIndex),
                                                                seed: effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
                                                                rotateDirection: effect.effectType == .direct ? nil : 1.0,
-                                                               zoomScale: effect.effectType == .direct ? nil : 1.001,
+                                                               rotateAngle: effect.effectType == .direct ? nil : 0.5,
+                                                               zoomScale: effect.effectType == .direct ? nil : 1.005,
                                                        progressHandler: { progress in
                         sampleTimer.stop()
                         DispatchQueue.main.async {

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -76,7 +76,9 @@ extension VideoStore {
                                                                toOutputUrl: fileURL,
                                                      prompt: effect.prompt,
                                                    strength: effect.strength(forFrameIndex: frameIndex),
-                                                               seed: effect.seed, //effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
+                                                               seed: effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
+                                                               rotateDirection: effect.effectType == .direct ? nil : 1.0,
+                                                               zoomScale: effect.effectType == .direct ? nil : 1.008,
                                                        progressHandler: { progress in
                         sampleTimer.stop()
                         DispatchQueue.main.async {

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -46,6 +46,10 @@ extension VideoStore {
         for frameIndex in effect.startFrame...effect.endFrame {
             var url: URL?
             if effect.effectType == .direct {
+                // i dont think this is needed anymore, but for older files it is....?
+                if frameIndex >= project.video.frames?.count ?? 0 {
+                    break
+                }
                 url = project.video.frames?[frameIndex].url
             } else if effect.effectType == .generative {
                 if frameIndex == 0 {

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -78,7 +78,7 @@ extension VideoStore {
                                                    strength: effect.strength(forFrameIndex: frameIndex),
                                                                seed: effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
                                                                rotateDirection: effect.effectType == .direct ? nil : 1.0,
-                                                               zoomScale: effect.effectType == .direct ? nil : 1.008,
+                                                               zoomScale: effect.effectType == .direct ? nil : 1.001,
                                                        progressHandler: { progress in
                         sampleTimer.stop()
                         DispatchQueue.main.async {
@@ -99,6 +99,7 @@ extension VideoStore {
                     }
                 } else {
                     await MainActor.run {
+                        print("INDEX: \(frameIndex)")
                         project.video.frames?[frameIndex].processedUrl = fileURL
                     }
                 }

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -81,9 +81,9 @@ extension VideoStore {
                                                      prompt: effect.prompt,
                                                    strength: effect.strength(forFrameIndex: frameIndex),
                                                                seed: effect.effectType == .direct ? effect.seed : UInt32.random(in: 0...UInt32.max),
-                                                               rotateDirection: effect.effectType == .direct ? nil : 1.0,
-                                                               rotateAngle: effect.effectType == .direct ? nil : 0.5,
-                                                               zoomScale: effect.effectType == .direct ? nil : 1.005,
+                                                               rotateDirection: effect.rotateDirection,
+                                                               rotateAngle: effect.rotateAngle,
+                                                               zoomScale: effect.zoomScale,
                                                        progressHandler: { progress in
                         sampleTimer.stop()
                         DispatchQueue.main.async {

--- a/Pokora/Model/VideoStore+Effects.swift
+++ b/Pokora/Model/VideoStore+Effects.swift
@@ -1,0 +1,95 @@
+//
+//  VideoStore+Effects.swift
+//  Pokora
+//
+//  Created by PJ Gray on 5/18/23.
+//
+
+import Foundation
+import StableDiffusion
+
+extension VideoStore {
+    func processEffects(modelURL: URL?) async {
+        await MainActor.run {
+            self.shouldProcess = true
+            self.isProcessing = true
+        }
+        for effect in project.effects {
+            do {
+                try await self.process(effect: effect, modelURL: modelURL)
+            } catch {
+                await MainActor.run {
+                    self.isProcessing = false
+                }
+            }
+            if !self.shouldProcess { break }
+        }
+        await MainActor.run {
+            self.isProcessing = false
+        }
+    }
+
+    private func process(effect: Effect, modelURL: URL?) async throws {
+        if pipeline == nil {
+            await MainActor.run {
+                self.timingStatus = ""
+                self.showThumbnails = false
+                self.processingStatus = "Initializing Pipeline..."
+            }
+            if let url = modelURL {
+                try initializePipeline(resourceURL: url)
+            } else {
+                try initializePipeline()
+            }
+        }
+
+        for frameIndex in effect.startFrame...effect.endFrame {
+            if let url = project.video.frames?[frameIndex].url {
+                let sampleTimer = SampleTimer()
+                sampleTimer.start()
+
+                await MainActor.run {
+                    let totalNumberFramesToProcess = project.effects.map({ $0.numberFramesToProcess }).reduce(0, +)
+                    let framesProcessed = project.video.frames?.compactMap { $0.processedUrl }.count ?? 0
+                    
+                    self.processingStatus = "\(totalNumberFramesToProcess - framesProcessed) frames remaining..."
+                }
+                
+                let name = (url.lastPathComponent.components(separatedBy: ".").first ?? "").appending("_processed.png")
+                let fileURL = url.deletingLastPathComponent().appending(path:name)
+                if !FileManager().fileExists(atPath: fileURL.path) {
+                    let processedUrl = try process(imageUrl: url,
+                                                     prompt: effect.prompt,
+                                                   strength: effect.strength(forFrameIndex: frameIndex),
+                                                       seed: effect.seed,
+                                                       progressHandler: { progress in
+                        sampleTimer.stop()
+                        DispatchQueue.main.async {
+                            self.showThumbnails = true
+                            let totalNumberFramesToProcess = self.project.effects.map({ $0.numberFramesToProcess }).reduce(0, +)
+                            let framesProcessed = self.project.video.frames?.compactMap { $0.processedUrl }.count ?? 0
+                            self.processingStatus = "Step #\(progress.step) of #\(progress.stepCount) (\(totalNumberFramesToProcess - framesProcessed) frames remaining)"
+                            self.timingStatus = "[ \(String(format: "mean: %.2f, median: %.2f, last %.2f", 1.0/sampleTimer.mean, 1.0/sampleTimer.median, 1.0/sampleTimer.allSamples.last!)) ] step/sec"
+                        }
+
+                        if progress.stepCount != progress.step {
+                            sampleTimer.start()
+                        }
+                        return shouldProcess
+                    })
+                    await MainActor.run {
+                        project.video.frames?[frameIndex].processedUrl = processedUrl
+                    }
+                } else {
+                    await MainActor.run {
+                        project.video.frames?[frameIndex].processedUrl = fileURL
+                    }
+                }
+
+            } else {
+                print("ERROR: should be an effect on #\(frameIndex), but didn't find url")
+            }
+            if !self.shouldProcess { break }
+        }
+    }
+}

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -27,19 +27,19 @@ extension VideoStore {
     internal func processImageToImage(withImageUrl imageUrl: URL, toOutputUrl outputUrl: URL, prompt: String, strength: Float, seed: UInt32, rotateDirection: CGFloat?, zoomScale: CGFloat?, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
         if let imageSource = CGImageSourceCreateWithURL(imageUrl as CFURL, nil), let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) {
             var startingImage = cgImage
-            if let rotateDirection = rotateDirection, let rotatedImage = self.rotateImage(image: startingImage, rotateDirection: rotateDirection) {
-                startingImage = rotatedImage
-            }
-            if let zoomScale = zoomScale, let zoomedImage = self.zoomInImage(image: startingImage, scale: zoomScale) {
-                startingImage = zoomedImage
-            }
+//            if let rotateDirection = rotateDirection, let rotatedImage = self.rotateImage(image: startingImage, rotateDirection: rotateDirection, rotateAngle: 0.2) {
+//                startingImage = rotatedImage
+//            }
+//            if let zoomScale = zoomScale, let zoomedImage = self.zoomInImage(image: startingImage, scale: zoomScale) {
+//                startingImage = zoomedImage
+//            }
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
             pipelineConfig.negativePrompt = ""
             pipelineConfig.startingImage = startingImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 30
+            pipelineConfig.stepCount = 50
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             
@@ -97,7 +97,7 @@ extension VideoStore {
             pipelineConfig.startingImage = cgImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 30
+            pipelineConfig.stepCount = 50
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -12,7 +12,7 @@ import UniformTypeIdentifiers
 
 extension VideoStore {
     
-    private func initializePipeline(resourceURL: URL = URL(filePath: "model_output/Resources")) throws {
+    internal func initializePipeline(resourceURL: URL = URL(filePath: "model_output/Resources")) throws {
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
 
@@ -24,7 +24,7 @@ extension VideoStore {
         try self.pipeline?.loadResources()
     }
     
-    private func process(imageUrl: URL, prompt: String, strength: Float, seed: UInt32, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
+    internal func process(imageUrl: URL, prompt: String, strength: Float, seed: UInt32, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
         if let imageSource = CGImageSourceCreateWithURL(imageUrl as CFURL, nil), let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) {
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
@@ -124,66 +124,5 @@ extension VideoStore {
             self.isProcessing = false
         }
         return nil
-    }
-    
-    internal func process(frame: Frame, atIndex index: Int, modelURL: URL?) async throws {
-        if pipeline == nil {
-            await MainActor.run {
-                self.timingStatus = ""
-                self.showThumbnails = false
-                self.processingStatus = "Initializing Pipeline..."
-            }
-            if let url = modelURL {
-                try initializePipeline(resourceURL: url)
-            } else {
-                try initializePipeline()
-            }
-        }
-        // TODO: The timing stuff here creates a dependency on StableDiffusion directly
-        // I'd rather have this abstracted behind a generic interface so other types
-        // of filters would work easily, and still be able to provide timing information.
-        //
-        // Added to Issue #35
-        if let url = frame.url, let effect = project.effects.first(where: { index >= $0.startFrame && index <= $0.endFrame }) {
-            let sampleTimer = SampleTimer()
-            sampleTimer.start()
-
-            await MainActor.run {
-                self.processingStatus = "Processing Frame #\(index) of #\((project.video.frames?.count ?? 0)-1)..."
-            }
-            
-            // kind of a hack, should pre-load this
-            let name = (url.lastPathComponent.components(separatedBy: ".").first ?? "").appending("_processed.png")
-            let fileURL = url.deletingLastPathComponent().appending(path:name)
-            if !FileManager().fileExists(atPath: fileURL.path) {
-                let processedUrl = try process(imageUrl: url,
-                                                 prompt: effect.prompt,
-                                               strength: effect.strength(forFrameIndex: index),
-                                                   seed: effect.seed,
-                                                   progressHandler: { progress in
-                    sampleTimer.stop()
-                    DispatchQueue.main.async {
-                        self.showThumbnails = true
-                        self.processingStatus = "Frame #\(index) - Step #\(progress.step) of #\(progress.stepCount)"
-                        self.timingStatus = "[ \(String(format: "mean: %.2f, median: %.2f, last %.2f", 1.0/sampleTimer.mean, 1.0/sampleTimer.median, 1.0/sampleTimer.allSamples.last!)) ] step/sec"
-                    }
-
-                    if progress.stepCount != progress.step {
-                        sampleTimer.start()
-                    }
-                    return shouldProcess
-                })
-                await MainActor.run {
-                    project.video.frames?[index].processedUrl = processedUrl
-                }
-            } else {
-                await MainActor.run {
-                    project.video.frames?[index].processedUrl = fileURL
-                }
-            }
-
-        } else {
-            print("No effect on frame \(index)")
-        }
-    }
+    }    
 }

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -24,7 +24,7 @@ extension VideoStore {
         try self.pipeline?.loadResources()
     }
     
-    internal func process(imageUrl: URL, prompt: String, strength: Float, seed: UInt32, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
+    internal func processImageToImage(withImageUrl imageUrl: URL, prompt: String, strength: Float, seed: UInt32, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
         if let imageSource = CGImageSourceCreateWithURL(imageUrl as CFURL, nil), let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) {
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -39,7 +39,7 @@ extension VideoStore {
             pipelineConfig.startingImage = startingImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 50
+            pipelineConfig.stepCount = 30
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             
@@ -97,7 +97,7 @@ extension VideoStore {
             pipelineConfig.startingImage = cgImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 50
+            pipelineConfig.stepCount = 30
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -24,12 +24,19 @@ extension VideoStore {
         try self.pipeline?.loadResources()
     }
     
-    internal func processImageToImage(withImageUrl imageUrl: URL, toOutputUrl outputUrl: URL, prompt: String, strength: Float, seed: UInt32, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
+    internal func processImageToImage(withImageUrl imageUrl: URL, toOutputUrl outputUrl: URL, prompt: String, strength: Float, seed: UInt32, rotateDirection: CGFloat?, zoomScale: CGFloat?, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
         if let imageSource = CGImageSourceCreateWithURL(imageUrl as CFURL, nil), let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) {
+            var startingImage = cgImage
+            if let rotateDirection = rotateDirection, let rotatedImage = self.rotateImage(image: startingImage, rotateDirection: rotateDirection) {
+                startingImage = rotatedImage
+            }
+            if let zoomScale = zoomScale, let zoomedImage = self.zoomInImage(image: startingImage, scale: zoomScale) {
+                startingImage = zoomedImage
+            }
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
             pipelineConfig.negativePrompt = ""
-            pipelineConfig.startingImage = cgImage
+            pipelineConfig.startingImage = startingImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
             pipelineConfig.stepCount = 30

--- a/Pokora/Model/VideoStore+StableDiffusion.swift
+++ b/Pokora/Model/VideoStore+StableDiffusion.swift
@@ -24,7 +24,7 @@ extension VideoStore {
         try self.pipeline?.loadResources()
     }
     
-    internal func processImageToImage(withImageUrl imageUrl: URL, toOutputUrl outputUrl: URL, prompt: String, strength: Float, seed: UInt32, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
+    internal func processImageToImage(withImageUrl imageUrl: URL, toOutputUrl outputUrl: URL, prompt: String, strength: Float, seed: UInt32, stepCount: Int, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?, progressHandler: (StableDiffusionPipeline.Progress) -> Bool = { _ in true }) throws -> URL? {
         if let imageSource = CGImageSourceCreateWithURL(imageUrl as CFURL, nil), let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) {
             
             var startingImage = cgImage
@@ -37,11 +37,11 @@ extension VideoStore {
             
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
-            pipelineConfig.negativePrompt = ""
+            pipelineConfig.negativePrompt = "watermark"
             pipelineConfig.startingImage = startingImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 50
+            pipelineConfig.stepCount = stepCount
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             
@@ -65,7 +65,7 @@ extension VideoStore {
         return nil
     }
 
-    func processPreview(imageUrl: URL, prompt: String, strength: Float, seed: UInt32, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?, modelURL: URL?) async throws -> CGImage? {
+    func processPreview(imageUrl: URL, prompt: String, strength: Float, seed: UInt32, stepCount: Int, rotateDirection: Effect.RotateDirection?, rotateAngle: Float?, zoomScale: Float?, modelURL: URL?) async throws -> CGImage? {
         await MainActor.run {
             self.showThumbnails = false
             self.shouldProcess = true
@@ -102,11 +102,11 @@ extension VideoStore {
 
             var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
-            pipelineConfig.negativePrompt = ""
+            pipelineConfig.negativePrompt = "watermark"
             pipelineConfig.startingImage = startingImage
             pipelineConfig.strength = strength
             pipelineConfig.imageCount = 1
-            pipelineConfig.stepCount = 50
+            pipelineConfig.stepCount = stepCount
             pipelineConfig.seed = seed
             pipelineConfig.guidanceScale = 7.5
             

--- a/Pokora/Model/VideoStore+Transformations.swift
+++ b/Pokora/Model/VideoStore+Transformations.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 import CoreImage
 
 extension VideoStore {
-    func rotateImage(image: CGImage, rotateDirection: CGFloat = 1.0) -> CGImage? {
+    func rotateImage(image: CGImage, rotateDirection: CGFloat = 1.0, rotateAngle: CGFloat = 0.333) -> CGImage? {
         let width = image.width
         let height = image.height
 
@@ -21,7 +21,7 @@ extension VideoStore {
 //        if promptIndex == 0 {
 //            rotateDirection = [1.0, -1.0].randomElement() ?? 1.0
 //        }
-        let rotateAngle: CGFloat = ((.pi / 180.0) * 0.333) * rotateDirection
+        let rotateAngle: CGFloat = ((.pi / 180.0) * rotateAngle) * rotateDirection
         context.rotate(by: rotateAngle)
         context.translateBy(x: -CGFloat(height) / 2.0, y: -CGFloat(width) / 2.0)
         context.draw(image, in: CGRect(x: CGFloat((width - height)) / 2.0, y: CGFloat((height - width)) / 2.0, width: CGFloat(height), height: CGFloat(width)))

--- a/Pokora/Model/VideoStore+Transformations.swift
+++ b/Pokora/Model/VideoStore+Transformations.swift
@@ -21,8 +21,8 @@ extension VideoStore {
 //        if promptIndex == 0 {
 //            rotateDirection = [1.0, -1.0].randomElement() ?? 1.0
 //        }
-        let rotateAngle: CGFloat = ((.pi / 180.0) * rotateAngle) * rotateDirection
-        context.rotate(by: rotateAngle)
+        let angleInRadians: CGFloat = ((.pi / 180.0) * rotateAngle) * rotateDirection
+        context.rotate(by: angleInRadians)
         context.translateBy(x: -CGFloat(height) / 2.0, y: -CGFloat(width) / 2.0)
         context.draw(image, in: CGRect(x: CGFloat((width - height)) / 2.0, y: CGFloat((height - width)) / 2.0, width: CGFloat(height), height: CGFloat(width)))
 

--- a/Pokora/Model/VideoStore+Transformations.swift
+++ b/Pokora/Model/VideoStore+Transformations.swift
@@ -1,0 +1,58 @@
+//
+//  VideoStore+Transformations.swift
+//  Pokora
+//
+//  Created by PJ Gray on 5/18/23.
+//
+
+import Foundation
+import CoreGraphics
+import CoreImage
+
+extension VideoStore {
+    func rotateImage(image: CGImage, rotateDirection: CGFloat = 1.0) -> CGImage? {
+        let width = image.width
+        let height = image.height
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: width * 4, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue)!
+
+        context.translateBy(x: CGFloat(width) / 2.0, y: CGFloat(height) / 2.0)
+//        if promptIndex == 0 {
+//            rotateDirection = [1.0, -1.0].randomElement() ?? 1.0
+//        }
+        let rotateAngle: CGFloat = ((.pi / 180.0) * 0.333) * rotateDirection
+        context.rotate(by: rotateAngle)
+        context.translateBy(x: -CGFloat(height) / 2.0, y: -CGFloat(width) / 2.0)
+        context.draw(image, in: CGRect(x: CGFloat((width - height)) / 2.0, y: CGFloat((height - width)) / 2.0, width: CGFloat(height), height: CGFloat(width)))
+
+        return context.makeImage()
+    }
+    
+    func zoomInImage(image: CGImage, scale: CGFloat = 1.008) -> CGImage? {
+        let ciImage = CIImage(cgImage: image)
+        let filter1 = CIFilter(name: "CIPerspectiveTransform")!
+        filter1.setValue(ciImage, forKey: kCIInputImageKey)
+        let extent = ciImage.extent
+        let width = extent.width * scale
+        let height = extent.height * scale
+        let x = extent.origin.x - (width - extent.width) / 2
+        let y = extent.origin.y - (height - extent.height) / 2
+        let topLeft = CIVector(x: extent.origin.x, y: y + height)
+        let topRight = CIVector(x: x + width, y: y + height)
+        let bottomRight = CIVector(x: x + width, y: y)
+        let bottomLeft = CIVector(x: extent.origin.x, y: y)
+        filter1.setValue(topLeft, forKey: "inputTopLeft")
+        filter1.setValue(topRight, forKey: "inputTopRight")
+        filter1.setValue(bottomRight, forKey: "inputBottomRight")
+        filter1.setValue(bottomLeft, forKey: "inputBottomLeft")
+
+        let filter2 = CIFilter(name: "CILanczosScaleTransform")!
+        filter2.setValue(filter1.outputImage, forKey: kCIInputImageKey)
+        filter2.setValue(scale, forKey: kCIInputScaleKey)
+        filter2.setValue(1, forKey: kCIInputAspectRatioKey)
+
+        let context = CIContext()
+        return context.createCGImage(filter2.outputImage!, from: extent)
+    }
+}

--- a/Pokora/Model/VideoStore+Video.swift
+++ b/Pokora/Model/VideoStore+Video.swift
@@ -98,7 +98,7 @@ extension VideoStore {
 
                             if FileManager().fileExists(atPath: path.path) {
                                 if let imageSize = NSImage(contentsOf: path)?.size, imageSize.width == 512 {
-                                    print("Skipped extracting: \(path.lastPathComponent)")
+                                    print("Skipped extracting: \(path.lastPathComponent) INDEX: \(index)")
                                     frames.append(Frame(index: index, url: path))
                                     index += 1
                                     continue
@@ -141,6 +141,7 @@ extension VideoStore {
 //                                }
 //                            }
                             frames.append(Frame(index: index, url: path))
+                            print("APPENDED \(index)")
                             index += 1
                         }
                         

--- a/Pokora/Model/VideoStore+Video.swift
+++ b/Pokora/Model/VideoStore+Video.swift
@@ -53,28 +53,6 @@ extension VideoStore {
             addTimeObserver()
         }
     }
-
-    func processFrames(modelURL: URL?) async {
-        await MainActor.run {
-            self.shouldProcess = true
-            self.isProcessing = true
-        }
-        for (index, frame) in (project.video.frames ?? []).enumerated() {
-            do {
-                try await self.process(frame: frame, atIndex: index, modelURL: modelURL)
-            } catch {
-                await MainActor.run {
-                    self.isProcessing = false
-                    // TODO: throw error here and use error dialog code
-//                        self.showErrorDialog(with: error)
-                }
-            }
-            if !self.shouldProcess { break }
-        }
-        await MainActor.run {
-            self.isProcessing = false
-        }
-    }
     
     func extractFrames() async {
         await MainActor.run {

--- a/Pokora/Navigation/ContentView.swift
+++ b/Pokora/Navigation/ContentView.swift
@@ -79,7 +79,7 @@ struct ContentView: View {
                                     if (store.project.video.frames?.count ?? 0) == 0 {
                                         await store.extractFrames()
                                     }
-                                    await store.processFrames(modelURL: modelURL)
+                                    await store.processEffects(modelURL: modelURL)
                                 }
                             }
                             .disabled(store.project.effects.isEmpty)

--- a/Pokora/Navigation/ContentView.swift
+++ b/Pokora/Navigation/ContentView.swift
@@ -30,6 +30,13 @@ struct ContentView: View {
                                         selectedEffect = effect.id
                                         showNewEffectSheet = true
                                     }
+                                    .contextMenu {
+                                        Button {
+                                            store.project.clearProcessedFrames(withEffect: effect.wrappedValue)
+                                        } label: {
+                                            Text("Clear Render")
+                                        }
+                                    }
                             }
                         }
                     }

--- a/Pokora/Navigation/EffectCell.swift
+++ b/Pokora/Navigation/EffectCell.swift
@@ -37,42 +37,49 @@ struct EffectCell: View {
                 .font(.title2)
                 .foregroundColor(.secondary)
 
-                HStack {
-                    if effect.startStrength == effect.endStrength {
-                        Image(systemName: "arrow.right.square.fill")
-                        Text("Strength: \(String(format: "%.3f", effect.startStrength))")
-                    } else if effect.startStrength < effect.endStrength {
-                        Image(systemName: "arrow.up.right.square.fill")
-                        Text("Strength: \(String(format: "%.3f ↗ %.3f", effect.startStrength, effect.endStrength))")
-                    } else {
-                        Image(systemName: "arrow.down.right.square.fill")
-                        Text("Strength: \(String(format: "%.3f ↘ %.3f", effect.startStrength, effect.endStrength))")
-                    }
-                }
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                
-                if effect.effectType == .direct {
-                    HStack {
-                        Image(systemName: "number.square.fill")
-                        Text("Seed: \(numberFormatter.string(from: NSNumber(value: effect.seed))!)")
-                    }
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                } else if effect.effectType == .generative {
-                    HStack {
-                        Image(systemName: "number.square.fill")
-                        Text("Rotate Angle: \(String(format: "%.3f", effect.rotateAngle ?? 0.0)) \(effect.rotateDirection == .clockwise ? "Clockwise" : "Counter Clockwise")")
-                    }
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                    HStack {
-                        Image(systemName: "number.square.fill")
-                        Text("Zoom Scale: \(String(format: "%.5f", effect.zoomScale ?? 0.0))")
-                    }
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                }
+                // still settling on this UI so leaving this commented for now
+//                HStack {
+//                    if effect.startStrength == effect.endStrength {
+//                        Image(systemName: "arrow.right.square.fill")
+//                        Text("Strength: \(String(format: "%.3f", effect.startStrength))")
+//                    } else if effect.startStrength < effect.endStrength {
+//                        Image(systemName: "arrow.up.right.square.fill")
+//                        Text("Strength: \(String(format: "%.3f ↗ %.3f", effect.startStrength, effect.endStrength))")
+//                    } else {
+//                        Image(systemName: "arrow.down.right.square.fill")
+//                        Text("Strength: \(String(format: "%.3f ↘ %.3f", effect.startStrength, effect.endStrength))")
+//                    }
+//                }
+//                .font(.subheadline)
+//                .foregroundColor(.secondary)
+//
+//                HStack {
+//                    Image(systemName: "number.square.fill")
+//                    Text("Step Count: \(numberFormatter.string(from: NSNumber(value: effect.stepCount ?? 0))!)")
+//                }
+//                .font(.subheadline)
+//                .foregroundColor(.secondary)
+//                if effect.effectType == .direct {
+//                    HStack {
+//                        Image(systemName: "number.square.fill")
+//                        Text("Seed: \(numberFormatter.string(from: NSNumber(value: effect.seed))!)")
+//                    }
+//                    .font(.subheadline)
+//                    .foregroundColor(.secondary)
+//                } else if effect.effectType == .generative {
+//                    HStack {
+//                        Image(systemName: "number.square.fill")
+//                        Text("Rotate Angle: \(String(format: "%.3f", effect.rotateAngle ?? 0.0)) \(effect.rotateDirection == .clockwise ? "Clockwise" : "Counter Clockwise")")
+//                    }
+//                    .font(.subheadline)
+//                    .foregroundColor(.secondary)
+//                    HStack {
+//                        Image(systemName: "number.square.fill")
+//                        Text("Zoom Scale: \(String(format: "%.5f", effect.zoomScale ?? 0.0))")
+//                    }
+//                    .font(.subheadline)
+//                    .foregroundColor(.secondary)
+//                }
                 
                 HStack {
                     Image(systemName: "film.fill")

--- a/Pokora/Navigation/EffectCell.swift
+++ b/Pokora/Navigation/EffectCell.swift
@@ -27,14 +27,14 @@ struct EffectCell: View {
                     .truncationMode(.tail)
                 HStack {
                     if effect.effectType == .direct {
-                        Image(systemName: "leaf.circle")
+                        Image(systemName: "arrowtriangle.forward.square.fill")
                         Text("Direct")
                     } else if effect.effectType == .generative {
-                        Image(systemName: "leaf.arrow.triangle.circlepath")
+                        Image(systemName: "arrow.uturn.right.square.fill")
                         Text("Generative")
                     }
                 }
-                .font(.title3)
+                .font(.title2)
                 .foregroundColor(.secondary)
 
                 HStack {
@@ -52,12 +52,14 @@ struct EffectCell: View {
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 
-                HStack {
-                    Image(systemName: "number.square.fill")
-                    Text("Seed: \(numberFormatter.string(from: NSNumber(value: effect.seed))!)")
+                if effect.effectType == .direct {
+                    HStack {
+                        Image(systemName: "number.square.fill")
+                        Text("Seed: \(numberFormatter.string(from: NSNumber(value: effect.seed))!)")
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
                 }
-                .font(.subheadline)
-                .foregroundColor(.secondary)
                 
                 HStack {
                     Image(systemName: "film.fill")

--- a/Pokora/Navigation/EffectCell.swift
+++ b/Pokora/Navigation/EffectCell.swift
@@ -25,7 +25,18 @@ struct EffectCell: View {
                     .foregroundColor(.primary)
                     .lineLimit(2)
                     .truncationMode(.tail)
-                
+                HStack {
+                    if effect.effectType == .direct {
+                        Image(systemName: "leaf.circle")
+                        Text("Direct")
+                    } else if effect.effectType == .generative {
+                        Image(systemName: "leaf.arrow.triangle.circlepath")
+                        Text("Generative")
+                    }
+                }
+                .font(.title3)
+                .foregroundColor(.secondary)
+
                 HStack {
                     if effect.startStrength == effect.endStrength {
                         Image(systemName: "arrow.right.square.fill")

--- a/Pokora/Navigation/EffectCell.swift
+++ b/Pokora/Navigation/EffectCell.swift
@@ -59,6 +59,19 @@ struct EffectCell: View {
                     }
                     .font(.subheadline)
                     .foregroundColor(.secondary)
+                } else if effect.effectType == .generative {
+                    HStack {
+                        Image(systemName: "number.square.fill")
+                        Text("Rotate Angle: \(String(format: "%.3f", effect.rotateAngle ?? 0.0)) \(effect.rotateDirection == .clockwise ? "Clockwise" : "Counter Clockwise")")
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    HStack {
+                        Image(systemName: "number.square.fill")
+                        Text("Zoom Scale: \(String(format: "%.5f", effect.zoomScale ?? 0.0))")
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
                 }
                 
                 HStack {

--- a/Pokora/Navigation/NewEffectView.swift
+++ b/Pokora/Navigation/NewEffectView.swift
@@ -32,15 +32,17 @@ struct NewEffectView: View {
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                     Stepper("Start Strength", value: $startStrength, step: 0.1, format: .number)
                     Stepper("End Strength", value: $endStrength, step: 0.1, format: .number)
-                    HStack {
-                        TextField("Seed", value: $seed, format: .number.grouping(.never))
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-                        Button {
-                            seed = UInt32.random(in: 0...UInt32.max)
-                        } label: {
-                            Label("", systemImage: "die.face.3.fill")
+                    if effectType == .direct {
+                        HStack {
+                            TextField("Seed", value: $seed, format: .number.grouping(.never))
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                            Button {
+                                seed = UInt32.random(in: 0...UInt32.max)
+                            } label: {
+                                Label("", systemImage: "die.face.3.fill")
+                            }
+                            .buttonStyle(BorderlessButtonStyle())
                         }
-                        .buttonStyle(BorderlessButtonStyle())
                     }
                 }
                 .formStyle(.grouped)

--- a/Pokora/Navigation/NewEffectView.swift
+++ b/Pokora/Navigation/NewEffectView.swift
@@ -15,6 +15,7 @@ struct NewEffectView: View {
     @State private var startStrength: Float = 0.2
     @State private var endStrength: Float = 0.2
     @State private var seed = globalSeed
+    @State private var stepCount: Double = 30
     @State private var cgImage: CGImage? = nil
     @State private var effectType: Effect.EffectType = .direct
     @State private var rotateAngle: Float = 0.5
@@ -35,6 +36,7 @@ struct NewEffectView: View {
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                     Stepper("Start Strength", value: $startStrength, step: 0.1, format: .number)
                     Stepper("End Strength", value: $endStrength, step: 0.1, format: .number)
+                    Stepper("Step Count", value: $stepCount, step: 1.0, format: .number)
                     if effectType == .direct {
                         HStack {
                             TextField("Seed", value: $seed, format: .number.grouping(.never))
@@ -75,11 +77,11 @@ struct NewEffectView: View {
                             // preview needs to take into account generative vs direct
                             if let id = selectedEffect {
                                 if let index = store.project.effects.firstIndex(where: { $0.id == id }), let url = store.project.video.frames?[ store.project.effects[index].startFrame ].url {
-                                    cgImage = try await store.processPreview(imageUrl: url, prompt: prompt, strength: startStrength, seed: seed, rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale, modelURL: modelURL)
+                                    cgImage = try await store.processPreview(imageUrl: url, prompt: prompt, strength: startStrength, seed: seed, stepCount: Int(stepCount), rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale, modelURL: modelURL)
                                 }
                             } else {
                                 if let url = store.project.video.frames?[ store.currentFrameNumber ?? 0 ].url {
-                                    cgImage = try await store.processPreview(imageUrl: url, prompt: prompt, strength: startStrength, seed: seed, rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale, modelURL: modelURL)
+                                    cgImage = try await store.processPreview(imageUrl: url, prompt: prompt, strength: startStrength, seed: seed, stepCount: Int(stepCount), rotateDirection: rotateDirection, rotateAngle: rotateAngle, zoomScale: zoomScale, modelURL: modelURL)
                                 }
                             }
                         }
@@ -100,13 +102,14 @@ struct NewEffectView: View {
                                 store.project.effects[index].startStrength = startStrength
                                 store.project.effects[index].endStrength = endStrength
                                 store.project.effects[index].seed = seed
+                                store.project.effects[index].stepCount = Int(stepCount)
                                 store.project.effects[index].effectType = effectType
                                 store.project.effects[index].rotateDirection = effectType == .direct ? nil : rotateDirection
                                 store.project.effects[index].rotateAngle = effectType == .direct ? nil : rotateAngle
                                 store.project.effects[index].zoomScale = effectType == .direct ? nil : zoomScale
                             }
                         } else {
-                            store.project.addEffect(effectType: effectType, startFrame: store.currentFrameNumber ?? 0, prompt: prompt, startStrength: startStrength, endStrength: endStrength, seed: seed, rotateDirection: effectType == .direct ? nil : rotateDirection, rotateAngle: effectType == .direct ? nil : rotateAngle, zoomScale: effectType == .direct ? nil : zoomScale)
+                            store.project.addEffect(effectType: effectType, startFrame: store.currentFrameNumber ?? 0, prompt: prompt, startStrength: startStrength, endStrength: endStrength, seed: seed, stepCount: Int(stepCount), rotateDirection: effectType == .direct ? nil : rotateDirection, rotateAngle: effectType == .direct ? nil : rotateAngle, zoomScale: effectType == .direct ? nil : zoomScale)
                         }
                         dismiss()
                     }
@@ -118,6 +121,7 @@ struct NewEffectView: View {
                     startStrength = effect.startStrength
                     endStrength = effect.endStrength
                     seed = effect.seed
+                    stepCount = Double(effect.stepCount ?? 30) 
                     effectType = effect.effectType ?? .direct
                     rotateAngle = effect.rotateAngle ?? 0.5
                     rotateDirection = effect.rotateDirection ?? .clockwise


### PR DESCRIPTION
This implements #59 

The idea is to use image2image, but rather than based on the underlying video frame (calling this a 'direct' effect), a 'generative' effect is based on the previous index processed frame. In my CLI I used a slower frame rate and ffmpeg to interpolate to get a nice look, so not sure exactly how I'll finish this, but the groundwork is there.

Todo:

- fix preview
- for generative effects if I dont change the seed it just goes to noise. not sure if there is a better way around that, but for now I just randomly assign a seed that is different to each frame. Currently I don't write these anywhere tho, so I wouldn't be able to recreate a given effect. I should write then to the effect for persisting to disk.